### PR TITLE
refactor nest_adapter to load network from NEST Desktop script 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,5 +20,5 @@
 	branch = main
 [submodule "nest-simulator"]
 	path = nest-simulator
-	url = https://github.com/VRGroupRWTH/nest-simulator.git
-	branch = feature/device_label	
+	url = https://github.com/nest/nest-simulator.git
+	branch = master	

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,5 +20,5 @@
 	branch = main
 [submodule "nest-simulator"]
 	path = nest-simulator
-	url = https://github.com/mfahdaz/nest-simulator.git
-	branch = cosim_mpi_patch	
+	url = https://github.com/VRGroupRWTH/nest-simulator.git
+	branch = feature/device_label	

--- a/run_usecase/local/cosim_launch_local_dev.sh
+++ b/run_usecase/local/cosim_launch_local_dev.sh
@@ -1,11 +1,11 @@
 killall -9 python3
 killall -9 mpirun
 
-export CO_SIM_ROOT_PATH="/home/vagrant/multiscale-cosim-repos/"
-export CO_SIM_MODULES_ROOT_PATH="${CO_SIM_ROOT_PATH}/TVB-NEST-usecase1"
+export CO_SIM_ROOT_PATH="/home/vagrant/multiscale-cosim/my_forks"
+export CO_SIM_MODULES_ROOT_PATH="${CO_SIM_ROOT_PATH}/Cosim_NestDesktop_Insite"
 export CO_SIM_USE_CASE_ROOT_PATH="${CO_SIM_MODULES_ROOT_PATH}"
-export PYTHONPATH=/home/vagrant/nest_installed/lib/python3.8/site-packages:/home/vagrant/multiscale-cosim-repos/TVB-NEST-usecase1
+export CO_SIM_PYTHONPATH=/home/vagrant/multiscale-cosim/my_forks/Cosim_NestDesktop_Insite:/home/vagrant/multiscale-cosim/site-packages:/home/vagrant/multiscale-cosim/nest/lib/python3.8/site-packages
 
-rm -r /home/vagrant/multiscale-cosim-repos/my_forks/TVB-NEST-usecase1/result_sim
+rm -r /home/vagrant/multiscale-cosim/my_forks/Cosim_NestDesktop_Insite/result_sim
 
-python3 ../../main.py --global-settings ../../EBRAINS_WorkflowConfigurations/general/global_settings.xml --action-plan ../../EBRAINS_WorkflowConfigurations/usecase/local/plans/cosim_alpha_brunel_local.xml
+python3 ../../main.py --global-settings ../../EBRAINS_WorkflowConfigurations/general/global_settings.xml --action-plan ../../userland/configs/local/plans/cosim_alpha_brunel_local.xml


### PR DESCRIPTION
this version of the `nest_adapter.py` serves as MVP for this showcase. It will be refactored to a generic adapter class and a specific model class.

The script `nd_spike_activity_test.py` is a placeholder for the script sent by NEST Desktop to the Cosim Server via REST.

the `.gitmodules` points to a fork of nest-simulator 3.4 with the newest MPI backend changes. Will be merged into NEST main soon. 