### PR TITLE
Fix bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,4 +126,6 @@ venv.bak/
 dmypy.json
 
 # Pyre type checker
-.pyre/ 
+.pyre/
+
+.vagrant/

--- a/installation/local/bootstrap.sh
+++ b/installation/local/bootstrap.sh
@@ -87,7 +87,7 @@ echo "1" | sudo update-alternatives --config mpirun 1>/dev/null 2>&1 # --> choos
 # STEP 3 - Install Python packages of TVB, NEST Desktop (and dependencies for NEST Server)
 #
 # NOTE: Specific versions are required for some packages
-pip install --no-cache --target=${CO_SIM_SITE_PACKAGES} \
+pip install --no-cache --upgrade --target=${CO_SIM_SITE_PACKAGES} \
         cython \
         elephant \
         flask \

--- a/installation/local/vagrantfile
+++ b/installation/local/vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure("2") do |config|
 
   # vagrant ouput name on console (during installation)
   config.vm.define "Cosim_NestDesktop_Insite_vm"
-  
+
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
   # `vagrant box outdated`. This is not recommended.
@@ -29,6 +29,8 @@ Vagrant.configure("2") do |config|
   # Add more ports here needed to be forwarded
   # nest_desktop
   config.vm.network "forwarded_port", guest: 54286, host: 54286
+  # nest_server
+  config.vm.network "forwarded_port", guest: 52425, host: 52425
   # cosim_app_server
   config.vm.network "forwarded_port", guest: 52428, host: 52428
   # insite access node
@@ -38,7 +40,7 @@ Vagrant.configure("2") do |config|
   # within the machine from a port on the host machine and only allow access
   # via 127.0.0.1 to disable public access
   # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.1.1"
-  
+
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
@@ -64,10 +66,10 @@ Vagrant.configure("2") do |config|
     # vb.gui = true
     # name of the VirtualBox GUI
     vb.name = "Cosim_NestDesktop_Insite"
-  
+
     # Customize the amount of memory on the VM:
     vb.memory = "8192"
-    
+
     #number of cpus
     vb.cpus = "4"
 


### PR DESCRIPTION
The bootstrap contains some unclear lines:

- Use newer cmake version (3.27)
- Install Python package correctly (otherwise some binaries will be lost)
- Remove unnecessary configs for NEST installation
- Insite should be installed after nest installation
- Insite installation config should find `nest-config`.
- Use Path to find binaries of python packages (`/home/vagrant/multiscale-cosim/site-packages/bin`)
- Add code to start nest-desktop and Insite in `run_on_local.sh`